### PR TITLE
Remove tzinfo from transaction.issued_at

### DIFF
--- a/sqlalchemy_continuum/transaction.py
+++ b/sqlalchemy_continuum/transaction.py
@@ -25,8 +25,9 @@ def utc_now():
     if sys.version_info >= (3, 11):
         # Use the new recommended approach
         from datetime import timezone
-
-        return datetime.now(timezone.utc)
+        # Generate the current time in UTC, and then strip tzinfo
+        # since the issued_at column below is not tz-aware
+        return datetime.now(timezone.utc).replace(tzinfo=None)
     else:
         # Fall back to the old approach for compatibility
         return datetime.utcnow()


### PR DESCRIPTION
# Problem
* When we recently picked up the latest `1.5.0` release, we immediately started seeing timezone errors for the issued_at field on the transaction table
* Python version: `3.12.4`

**Error Message**
```
sqlalchemy.exc.DBAPIError: (sqlalchemy.dialects.postgresql.asyncpg.Error) <class 'asyncpg.exceptions.DataError'>: invalid input for query argument $2: datetime.datetime(2025, 10, 1, 15, 0, 38... (can't subtract offset-naive and offset-aware datetimes)
[SQL: INSERT INTO transaction (id, remote_addr, issued_at) VALUES (nextval('transaction_id_seq'), $1::VARCHAR, $2::TIMESTAMP WITHOUT TIME ZONE) RETURNING transaction.id]
[parameters: (None, datetime.datetime(2025, 10, 1, 15, 0, 38, 781, tzinfo=datetime.timezone.utc))]
```

Debugging, we traced this back to a change in the transaction base class.

Previously, the class was using `datetime.utcnow()` which returned a Datetime object that is not timezone aware. Recently this was updated to return `datetime.now(timezone.utc)` which is a timezone-aware object, for versions of python above `3.11`. In this case, this conflicts with the `issued_at` column definition which is configured to NOT be timezone aware.

In our testing, stripping the timezone like in this PR resolved this issue. We've had to pin `sqlalchemy-continuum` to `1.4.2` due to this issue.